### PR TITLE
dontLogTCPWrappersConnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 snmp cookbook CHANGELOG
 =======================
+v5.0.2
+------
+* allow a config to skip connection logging (dontLogTCPWrappersConnects)
+
 v5.0.0
 ------
 @florian-asche

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,6 +76,7 @@ default['snmp']['snmpd']['ignoredisks'] = []
 default['snmp']['snmpd']['skipNFSInHostResources'] = nil
 default['snmp']['snmpd']['load_average'] = []
 default['snmp']['snmpd']['trapsinks'] = []
+default['snmp']['snmpd']['dontLogTCPWrappersConnects'] = nil
 default['snmp']['snmptrapd']['trapcommunity'] = 'public'
 default['snmp']['snmptrapd']['trapd_run'] = 'no'
 default['snmp']['snmpd']['extend_scripts'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'snmp'
 maintainer 'Thomas Vincent'
 maintainer_email 'thomasvincent@gmail.com'
 license 'Apache-2.0'
-version '5.0.1'
+version '5.0.2'
 description 'Installs and configures snmpd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/thomasvincent/cookbook-snmp'

--- a/templates/default/snmpd.conf.erb
+++ b/templates/default/snmpd.conf.erb
@@ -114,6 +114,17 @@ rocommunity <%= node['snmp']['snmpd']['community'] %> 127.0.0.1
 <% end %>
 
 ###############################################################################
+# Logging
+#
+# We do not want annoying "Connection from UDP: " messages in syslog.
+# If the following option is commented out, snmpd will print each incoming
+# connection, which can be useful for debugging.
+
+<% if node.read('snmp', 'dontLogTCPWrappersConnects') %>
+dontLogTCPWrappersConnects <%= node['snmp']['dontLogTCPWrappersConnects'] %>
+<% end %>
+
+###############################################################################
 # Process monitoring
 #
 #  See the snmpd.conf manual page, and the output of "snmpd -H".


### PR DESCRIPTION
 - allow a config to skip connection logging (dontLogTCPWrappersConnects)

### Description

This change revives a stanza and config from an old default snmpd.conf file.  It lays in a config to NOT log UDP/TCP connections to syslog.  Comment text is preserved from original (it's not me editorializing, for instance!)

### Issues Resolved

None.  It's an old feature.

### Check List

- [x ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
  - organized testing not possible at work
- [x ] New functionality includes testing.
  - organized testing not possible at work
- [x ] New functionality has been documented in the README if applicable
  - oops.  totally omitted
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
   - not signing.   I'm just delivering a patch. 